### PR TITLE
Handle also singlepart messsages

### DIFF
--- a/lib/slactionmailer/message.rb
+++ b/lib/slactionmailer/message.rb
@@ -10,7 +10,7 @@ module SlactionMailer
     end
 
     def body
-      @mail.text_part.body.decoded
+      @mail.multipart? ? @mail.text_part.body.decoded : @mail.body.decoded
     end
 
     def from

--- a/spec/slaction_mailer/delivery_method_spec.rb
+++ b/spec/slaction_mailer/delivery_method_spec.rb
@@ -5,8 +5,6 @@ describe SlactionMailer::DeliveryMethod do
 
     Mail.defaults do
       delivery_method SlactionMailer::DeliveryMethod, 
-        :webhook => "https://hooks.slack.com/services/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", 
-        :channel => "#bottesting", 
         :username => "SlactionMailer"
     end
   end
@@ -23,18 +21,19 @@ describe SlactionMailer::DeliveryMethod do
     it 'sends a message with a template' do
       Mail.defaults do
         delivery_method SlactionMailer::DeliveryMethod, 
-          :webhook => "https://hooks.slack.com/services/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", 
-          :channel => "#bottesting", 
           :username => "SlactionMailer",
           :template => File.read('spec/examples/template.text.erb')
       end
       expect { 
-        Mail.deliver do
+        mail = Mail.new do
           from "Feaux feaux@example.com"
           to "Bar bar@example.com"
           subject "Hello World!"
           body "I'm a message body!"
         end
+        mail[:channel] = '#bottesting'
+        mail[:webhook] = 'https://hooks.slack.com/services/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'
+        mail.deliver
       }.not_to raise_error
     end
   end

--- a/spec/slaction_mailer/message_spec.rb
+++ b/spec/slaction_mailer/message_spec.rb
@@ -9,13 +9,13 @@ describe SlactionMailer::Message do
       body    'This is the email body'
     end 
   }
-  it 'can run without a template' do
-    expect { message = SlactionMailer::Message.new(mail) }.not_to raise_error
+  it 'can render without a template' do
+    expect { message = SlactionMailer::Message.new(mail).result }.not_to raise_error
   end
 
-  it 'can use a template' do
+  it 'can render a template' do
     template = File.read('spec/examples/template.text.erb')
-    expect { message = SlactionMailer::Message.new(mail, :template => template) }.not_to raise_error
+    expect { message = SlactionMailer::Message.new(mail, :template => template).result }.not_to raise_error
   end
 
   it 'renders attachments properly' do


### PR DESCRIPTION
When a singlepart message is passed to the delivery method
an undefined method error is raised:

  undefined method `body' for nil:NilClass>

This is because the message class expects the content to be a mime-part.
In case of a singlepart message the content is in the message body.

This will use the body on singlepart messages and the text_part for
multipart messages.
It also extends the tests to cover the changed code.